### PR TITLE
wip fix generated TS

### DIFF
--- a/src/classGenerator.ts
+++ b/src/classGenerator.ts
@@ -3,9 +3,11 @@
  */
 import {
   ClassDefinition,
+  ClassPropertyDefinition,
   createFile,
   EnumDefinition,
   FileDefinition,
+  TypeDefinition,
 } from "ts-code-generator";
 import { DOMParser } from "xmldom-reborn";
 import { ASTNode, getFieldType, NEWLINE } from "./parsing";
@@ -524,6 +526,13 @@ export class ClassGenerator {
           classDef.methods = c.methods;
           classDef.isExported = true;
           classDef.isAbstract = c.isAbstract;
+          let classProperty = new ClassPropertyDefinition();
+          classProperty.name = `["@class"]`;
+          classProperty.isReadonly = true;
+          let stringTypedef = new TypeDefinition();
+          stringTypedef.text = "string";
+          classProperty.type = stringTypedef;
+          this.addProtectedPropToClass(classDef, classProperty);
           c.extendsTypes.forEach((t) => classDef.addExtends(t.text));
           c.getPropertiesAndConstructorParameters().forEach((prop) => {
             const ct = sortedClasses.filter(
@@ -598,6 +607,10 @@ export class ClassGenerator {
          */
         const isOptional = prop.name.indexOf("?") >= 0;
         const propName = prop.name.replace("?", "");
+        if (propName === `["@class"]`) {
+          // Skip @class property, already assigned.
+          return;
+        }
         console.log({ label: "makeConstructor()", prop, propName });
         if (outFile.getClass(prop.type.text) != null) {
           codeLines.push(

--- a/src/classGenerator.ts
+++ b/src/classGenerator.ts
@@ -153,8 +153,10 @@ function addClassForASTNode(
           returnType: "void",
           scope: "protected",
         });
+        console.log({ attr: m.attr });
         method.addParameter({
           name: "arg",
+          // For redundant class, this should return the existing class instead of a new ref.
           type: m.attr.fieldType || capfirst(m.attr.ref),
         });
         method.onWriteFunctionBody = (w) => {
@@ -567,6 +569,10 @@ export class ClassGenerator {
     log("ready");
     log("redundantArrayClasses", redundantArrayClasses);
     outFile.classes = outFile.classes.filter(
+      // @assumption: Asset and OtherAsset are filtered out here, that's why we don't get the class back
+      // That assumption is true, but we're not supposed to use redundant class,
+      // e.g. for HomePhone element, it's a sequence of Phone, instead of making another class for HomePhone
+      // we can just use array of Phone instead.
       (c) => redundantArrayClasses.indexOf(c.name) < 0
     );
     log(
@@ -611,7 +617,14 @@ export class ClassGenerator {
           // Skip @class property, already assigned.
           return;
         }
-        console.log({ label: "makeConstructor()", prop, propName });
+        if (propName === "Asset" || propName === "OtherAsset") {
+          console.log({
+            label: "makeConstructor()",
+            prop,
+            propName,
+            class: outFile.getClass(prop.type.text),
+          });
+        }
         if (outFile.getClass(prop.type.text) != null) {
           codeLines.push(
             isOptional

--- a/test/generator.spec.ts
+++ b/test/generator.spec.ts
@@ -125,7 +125,7 @@ describe("generator", () => {
         "./test/xsd/FMS-ApplicationBatchRequest-1_0.xsd"
       )
     );
-    printFile("./src/generated/FMS-ApplicationBatchRequest-1_0.ts");
+    // printFile("./src/generated/FMS-ApplicationBatchRequest-1_0.ts");
     compile("./src/generated/FMS-ApplicationBatchRequest-1_0.ts");
   });
 });


### PR DESCRIPTION
A WIP

The error count is already down to 6 from 1k+
![image](https://user-images.githubusercontent.com/19742419/132523201-87b48f5e-def7-47ee-bede-f106b371c67f.png)

6 errors are caused by 2 issues:
1. For some element that just an array of existing elements, it should just use the class of the existing element for the array instead of creating new class.
E.g. for HomePhone element, it's a sequence of Phone, and we already have Phone class. So the generator should use Array<Phone> instead of creating HomePhone class.
But some elements in the generated TS tried to use the nonexisting class, e.g.
Asset, instead of using Array<RelatedEntityRef>, it tries to use Asset class.
2. xs.Time missing type, looks like it should be coming from another dependency xsd, like this one https://www.w3.org/2001/XMLSchema.xsd